### PR TITLE
issue-35-Prevent_callables_from_using_kwargs

### DIFF
--- a/examples/mnist_example.ipynb
+++ b/examples/mnist_example.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "### Defining losses and metrics\n",
     "\n",
-    "Since losses can have a significant impact on performance, we may want to treat loss as a hyperparameter. Additionally, losses may have hyperparameters like label smoothting that can impact performance. Here we define a nested dictionary that randomizes choice of a hinge or cross entropy loss, and that defines label smoothing as a hyperparameter for cross entropy. Each loss has a `name` that is decoded by the model builder function to generate a `tf.keras.losses.Loss` object, and an optional `kwargs` dictionary that is used to create this object.\n",
+    "Since losses and their parameters can have a significant impact on performance, we may want to treat them as tunable hyperparameters. For example, properties like label smoothing thresholds can be searched to identify optimal values. Here we define a nested dictionary that randomizes choice of a hinge or cross entropy loss, and that defines label smoothing as a hyperparameter for cross entropy. Each loss has a `name` that defines how this loss is registered and reported by Ray Tune, and a `loss` parameter that defines a `tf.keras.losses.Loss` subclass. An optional `kwargs` dictionary is used to customize the class instance when it is created during a trial.\n",
     "\n",
     "Loss weights are assigned for each loss, and can set as hyperparameters, although here we set the loss weight to 1.\n",
     "\n",

--- a/glimr/keras.py
+++ b/glimr/keras.py
@@ -1,4 +1,3 @@
-from functools import partial
 import inspect
 import tensorflow as tf
 
@@ -39,7 +38,9 @@ def keras_losses(config):
 
         # create loss object
         if inspect.isfunction(task["loss"]["loss"]):
-            loss = partial(task["loss"]["loss"], **kwargs)
+            if kwargs != {}:
+                raise ValueError("functional losses cannot use kwargs")
+            loss = task["loss"]["loss"]
         elif inspect.isclass(task["loss"]["loss"]):
             loss = task["loss"]["loss"](**kwargs)
         else:


### PR DESCRIPTION
Using kwargs with functional losses via functools.partial prevents tensorflow from saving the model (not picklable). Raise error when kwargs are passed with functional losses.

